### PR TITLE
Small tweaks for docs-build.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -297,5 +297,5 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'iris': ('http://scitools.org.uk/iris/docs/latest/', None),
+    'iris': ('https://scitools-iris.readthedocs.io/en/latest/', None),
 }

--- a/docs/ref/release_notes.rst
+++ b/docs/ref/release_notes.rst
@@ -18,7 +18,7 @@ Bugs Fixed
   `cartopy <https://scitools.org.uk/cartopy/docs/latest/>`_, including casting
   the usage of :meth:`cf_units.Unit.date2num` as float. setting and setting the
   values of some missing keys using ``gribapi.GRIB_MISSING_LONG``.
-  `(PR#271) <https://github.com/SciTools/iris-grib/pull/288>`_
+  `(PR#288) <https://github.com/SciTools/iris-grib/pull/288>`_
 
 
 Dependencies
@@ -228,6 +228,7 @@ Features
 
 * Updated translations between GRIB parameter code and CF standard_name or
   long_name :
+
       * additional WAFC codes, both to and from CF
       * 'mass_fraction_of_cloud_liquid_water_in_air' and 'mass_fraction_of_cloud_ice_in_air', both to and from CF
       * 'surface_downwelling_longwave_flux_in_air', now translates to GRIBcode(2, 0, 5, 3)  (but not the reverse).


### PR DESCRIPTION
Fixed some problems I found.
Original build output lokked like this ...

itpp@vld321 $ make clean html 
rm -rf _build/*
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v4.2.0
making output directory... done
**WARNING: html_static_path entry '_static' does not exist**
loading intersphinx inventory from https://docs.python.org/objects.inv...
loading intersphinx inventory from http://scitools.org.uk/iris/docs/latest/objects.inv...
intersphinx inventory has moved: https://docs.python.org/objects.inv -> https://docs.python.org/3/objects.inv
**WARNING: failed to reach any of the inventories with the following issues:**
**intersphinx inventory 'http://scitools.org.uk/iris/docs/latest/objects.inv' not fetchable due to <class 'requests.exceptions.HTTPError'>: 404 Client Error: Not Found for url: https://scitools.org.uk/iris/docs/latest/objects.inv**
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 5 source files that are out of date
updating environment: [new config] 5 added, 0 changed, 0 removed
reading sources... [100%] ref/release_notes                                                                                                                  
**/net/home/h05/itpp/git/iris_grib/docs/ref/release_notes.rst:2: WARNING: Duplicate explicit target name: "(pr#271)".**
**/net/home/h05/itpp/git/iris_grib/docs/ref/release_notes.rst:231: WARNING: Unexpected indentation.**
looking for now-outdated files... none found
pickling environment... done
checking consistency... **/net/home/h05/itpp/git/iris_grib/docs/ref/release_notes.rst: WARNING: document isn't included in any toctree**
done
preparing documents... done
writing output... [100%] ref/release_notes                                                                                                                   
generating indices... genindex py-modindex done
writing additional pages... search done
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 5 warnings.

The HTML pages are in _build/html.

Build finished. The HTML pages are in _build/html.

----

This fixes 3/5 problems, I think.
But I'm still getting ...
```
WARNING: html_static_path entry '_static' does not exist
/net/home/h05/itpp/git/iris_grib/docs/ref/release_notes.rst: WARNING: document isn't included in any toctree
```
I think those are OK 
  - there is no "docs/_static" directory, cos we don't need one
  - the release-notes don't need to appear in a TOC
